### PR TITLE
Fix Type mismatch when paying with a donation

### DIFF
--- a/src/model/PaymentItem/DonationPaymentItem.php
+++ b/src/model/PaymentItem/DonationPaymentItem.php
@@ -12,11 +12,11 @@ class DonationPaymentItem implements PaymentItemInterface
 
     private $vat;
 
-    public function __construct(string $name, float $price, int $vat)
+    public function __construct(string $name, float $price, string $vat)
     {
         $this->name = $name;
         $this->price = $price;
-        $this->vat = $vat;
+        $this->vat = (int)$vat;
     }
 
     public function type(): string


### PR DESCRIPTION
I needed to fix donations with any type of subscription where I was using the stripe module with it.
For some reason, the donation wasn't properly casted to integer when the DonationItem class constructor was called so I did that inside the class itself while accepting a string.  